### PR TITLE
fix "this if clause dose not guard... -Werror=misleading-indentation"

### DIFF
--- a/dynasm/dasm_x86.h
+++ b/dynasm/dasm_x86.h
@@ -204,7 +204,8 @@ void dasm_put(Dst_DECL, int start, ...)
       case DASM_SPACE: p++; ofs += n; break;
       case DASM_SETLABEL: b[pos-2] = -0x40000000; break;  /* Neg. label ofs. */
       case DASM_VREG: CK((n&-8) == 0 && (n != 4 || (*p&1) == 0), RANGE_VREG);
-	if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;
+	if (*p++ == 1 && *p == DASM_DISP) mrm = n;
+	continue;
       }
       mrm = 4;
     } else {


### PR DESCRIPTION
dynasm/dasm_x86.h:207:2: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
  if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;

gcc version 7.3.0 (Ubuntu 7.3.0-27ubuntu1~18.04)